### PR TITLE
Add GitHub Action to notify Slack on PR readiness

### DIFF
--- a/.github/workflows/notify-slack-pr-ready.yml
+++ b/.github/workflows/notify-slack-pr-ready.yml
@@ -31,7 +31,7 @@ jobs:
             "blocks": [
               {
                 "type": "header",
-                "text": { "type": "plain_text", "text": "🧵 PR Ready for Review", "emoji": true }
+                "text": { "type": "plain_text", "text": "🚢 PR Ready for Review", "emoji": true }
               },
               {
                 "type": "section",


### PR DESCRIPTION
## Description

- This only triggers when someone clicks “Ready for review” on a draft PR.
- It will not trigger on opened / pushed commits / sync / reopened, so there is no spam.
- In Slack, people just hit Reply in thread on that message and that becomes our PR review thread.