### PR TITLE
chore/migration-clerk-id-to-pk

### DIFF
--- a/backend/supabase/migrations/20260214170923_make-clerk-id-pk-users.sql
+++ b/backend/supabase/migrations/20260214170923_make-clerk-id-pk-users.sql
@@ -1,0 +1,15 @@
+-- make clerk id be the actual pk and drop db generated id column, adjusting the foreign key
+-- in requests table
+
+ALTER TABLE public.requests
+    DROP COLUMN user_id;
+
+ALTER TABLE public.users
+    DROP COLUMN id,
+    ADD PRIMARY KEY (clerk_id);
+
+ALTER TABLE public.users RENAME COLUMN clerk_id TO id;
+
+ALTER TABLE public.requests
+    ADD COLUMN user_id TEXT REFERENCES public.users(id) ON DELETE SET NULL;
+


### PR DESCRIPTION
- data layer migration for using clerk id as the primary key in the users table

Related to #88 