### PR TITLE
chore: codecov checks are informational rather than blocking/error

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,10 +4,12 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        informational: true
     patch:
       default:
         target: auto
         threshold: 1%
+        informational: true
 
 comment:
   layout: "reach,diff,flags,files"


### PR DESCRIPTION
Makes codecov checks informational

<img width="1666" height="724" alt="CleanShot 2026-03-19 at 11 57 59@2x" src="https://github.com/user-attachments/assets/02b02f86-dffd-40c7-a0e9-c4f4774e31f2" />