### PR TITLE
fix: mobile navbar padding + shift create button up

### DIFF
--- a/clients/mobile/app/(tabs)/_layout.tsx
+++ b/clients/mobile/app/(tabs)/_layout.tsx
@@ -28,7 +28,7 @@ const TabBarIcon = ({ name, focused, activeColor, label }: TabBarIconProps) => (
 );
 
 const PlusButton = () => (
-  <View className="bg-primary rounded-full w-14 h-14 items-center justify-center -mb-2">
+  <View className="bg-primary rounded-full size-16 items-center justify-center mb-6">
     <IconSymbol size={22} name="plus" color={Colors["light"].background} />
   </View>
 );

--- a/clients/mobile/app/(tabs)/_layout.tsx
+++ b/clients/mobile/app/(tabs)/_layout.tsx
@@ -48,10 +48,12 @@ export default function TabLayout() {
         tabBarActiveTintColor: c.tabBarActive,
         tabBarInactiveTintColor: c.tabBarActive,
         tabBarItemStyle: {
-          paddingVertical: 10,
+          paddingVertical: 0,
         },
         tabBarStyle: {
-          height: 70,
+          paddingTop: 8,
+          paddingHorizontal: 20,
+          height: 68,
         },
       }}
     >


### PR DESCRIPTION
padding to match figma  + shift create task button up to avoid conflict w/ phone scroll up to nav to home

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/8d1bbdb5-4be3-42f5-bebd-ef7ce1ee801e" />


