### PR TITLE
feat: Add dynamic hotel-id injection [CHECK IF WORKS LOCALLY]

### DIFF
--- a/clients/shared/src/api/client.ts
+++ b/clients/shared/src/api/client.ts
@@ -10,11 +10,7 @@ export const createRequest = (
 ) => {
   return async <T>(config: RequestConfig): Promise<T> => {
     const hotelId = getConfig().hotelId;
-    const normalizedUrl =
-      baseUrl.endsWith("/api/v1") && config.url.startsWith("/api/v1/")
-        ? config.url.replace(/^\/api\/v1/, "")
-        : config.url;
-    let fullUrl = `${baseUrl}${normalizedUrl}`;
+    let fullUrl = `${baseUrl}${config.url}`;
     if (config.params && Object.keys(config.params).length > 0) {
       const searchParams = new URLSearchParams(config.params);
       fullUrl += "?" + searchParams.toString();

--- a/clients/shared/src/api/client.ts
+++ b/clients/shared/src/api/client.ts
@@ -8,12 +8,16 @@ export const createRequest = (
   getToken: () => Promise<string | null>,
   baseUrl: string,
 ) => {
-  const hardCodedHotelId = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
   return async <T>(config: RequestConfig): Promise<T> => {
-    let fullUrl = `${baseUrl}${config.url}`;
+    const hotelId = getConfig().hotelId;
+    const normalizedUrl =
+      baseUrl.endsWith("/api/v1") && config.url.startsWith("/api/v1/")
+        ? config.url.replace(/^\/api\/v1/, "")
+        : config.url;
+    let fullUrl = `${baseUrl}${normalizedUrl}`;
     if (config.params && Object.keys(config.params).length > 0) {
       const searchParams = new URLSearchParams(config.params);
-      fullUrl += '?' + searchParams.toString();
+      fullUrl += "?" + searchParams.toString();
     }
 
     try {
@@ -24,7 +28,7 @@ export const createRequest = (
         headers: {
           "Content-Type": "application/json",
           ...(token && { Authorization: `Bearer ${token}` }),
-          "X-Hotel-ID": hardCodedHotelId,
+          "X-Hotel-ID": hotelId,
           ...config.headers,
         },
         body: config.data ? JSON.stringify(config.data) : undefined,

--- a/clients/shared/src/api/client.ts
+++ b/clients/shared/src/api/client.ts
@@ -104,10 +104,5 @@ export const getBaseUrl = (): string => {
     throw new Error("API_BASE_URL is not configured. Check your .env file.");
   }
 
-  const trimmed = url.replace(/\/+$/, "");
-  if (trimmed.endsWith("/api/v1")) {
-    return trimmed;
-  }
-
-  return `${trimmed}/api/v1`;
+  return url;
 };


### PR DESCRIPTION
## Description
 Essentially, requests now follow whatever hotel id your backend user record has on that machine.
 
 According to chat:
 What’s covered right now:

  - The frontend no longer relies on one hardcoded hotel id.
  - Web/mobile startup fetch the backend user and store hotelId in shared config.
  - The shared API client sends that hotelId as X-Hotel-ID.
  - So requests now follow whatever hotel id your backend user record has on that machine.

  What is not covered:

  - A full move to Clerk org metadata as the source of truth.
  - A guaranteed org_... hotel-id format everywhere.
  - Consistent backend data/seed/docs/tests all using org_....
  - No-org flows based on Clerk organization membership.
  - Full certainty that every backend endpoint now expects the same hotel-id format.

  That’s the limbo state: some backend models/validation/docs are moving toward org_..., but your actual seeded/local data and current user records may still be plain UUIDs.