### PR TITLE
chore: remove unused import in guest page

### DIFF
--- a/clients/mobile/app/(tabs)/guests/index.tsx
+++ b/clients/mobile/app/(tabs)/guests/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { View, FlatList, ActivityIndicator } from "react-native";
-import { Header } from "@/components/ui/header";
 import { GuestCard } from "@/components/ui/guest-card";
 import { router } from "expo-router";
 import { useAPIClient } from "@shared/api/client";


### PR DESCRIPTION
fixes
```
  3:10  warning  'Header' is defined but never used  @typescript-eslint/no-unused-vars
```